### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,12 @@ Package: poisdata
 Title: Read and Write Data
 Version: 0.0.1.9002
 Authors@R: c(
-    person("Joe", "Thorley", email = "joe@poissonconsulting.ca", role = c("aut", "cre")),
-    person("Seb", "Dalgarno", role = "aut"),
-    person("Colton", "Stephens", role = "ctb")
+    person("Joe", "Thorley", email = "joe@poissonconsulting.ca", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-7683-4592")),
+    person("Seb", "Dalgarno", role = "aut",
+           comment = c(ORCID = "0000-0002-3658-4517")),
+    person("Colton", "Stephens", role = "ctb",
+           comment = c(ORCID = "0000-0002-8744-6405"))
     )
 Description: Functions to read and write data for Poisson Consulting scripts and packages.
 License: MIT + file LICENSE


### PR DESCRIPTION
Add ORCIDs for Joe Thorley, Seb Dalgarno, and Colton Stephens.

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)